### PR TITLE
Don't start Janus Gateway by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,11 +7,10 @@ This package configure Janus Gateway https://github.com/meetecho/janus-gateway
 Start Janus Gateway at boot
 ===========================
 
-To start Janus Gateway, launch
-`systemctl start janus-gateway`
+To start Janus Gateway and enable it at boot, execute: ::
 
-To start it at boot
-`config setprop janus-gateway status enabled`
+  config setprop janus-gateway status enabled
+  /etc/e-smith/events/actions/runlevel-adjust
 
 
 NAT modes

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,16 @@ nethserver-janus
 
 This package configure Janus Gateway https://github.com/meetecho/janus-gateway
 
+Start Janus Gateway at boot
+===========================
+
+To start Janus Gateway, launch
+`systemctl start janus-gateway`
+
+To start it at boot
+`config setprop janus-gateway status enabled`
+
+
 NAT modes
 =========
 

--- a/root/etc/e-smith/db/configuration/defaults/janus-gateway/status
+++ b/root/etc/e-smith/db/configuration/defaults/janus-gateway/status
@@ -1,1 +1,1 @@
-enabled
+disabled


### PR DESCRIPTION
Janus NAT mode is STUN by default. If it isn't able to reach STUN server, maybe because it is started without network connection, it keep failing (because of https://github.com/NethServer/dev/issues/5426)

This could lead to problem like this one https://github.com/nethesis/dev/issues/5420