### PR TITLE
Requires janus >= 0.7.0 manually made to support DTLS 1.2 needed by new Chrome M74 release

### DIFF
--- a/nethserver-janus.spec
+++ b/nethserver-janus.spec
@@ -7,7 +7,7 @@ License: GPLv3
 BuildArch: noarch
 Packager: Nethesis <info@nethesis.it>
 Source0: %{name}-%{version}.tar.gz
-Requires: janus-gateway >= 0.6.3
+Requires: janus-gateway >= 0.7.0
 BuildRequires: nethserver-devtools
 
 %description


### PR DESCRIPTION
NethServer/dev#5740