### PR TITLE
Require janus 0.7.6.0: aligned with upstream a71354b (> 0.7.6)

### DIFF
--- a/nethserver-janus.spec
+++ b/nethserver-janus.spec
@@ -7,7 +7,7 @@ License: GPLv3
 BuildArch: noarch
 Packager: Nethesis <info@nethesis.it>
 Source0: %{name}-%{version}.tar.gz
-Requires: janus-gateway >= 0.7.4.0
+Requires: janus-gateway >= 0.7.6.0
 BuildRequires: nethserver-devtools
 
 %description


### PR DESCRIPTION
nethserver/dev#5914