### PR TITLE
spec: inc spec version only to restart new janus versione 0.7.6.0-2

### DIFF
--- a/nethserver-janus.spec
+++ b/nethserver-janus.spec
@@ -1,6 +1,6 @@
 Name:    nethserver-janus
 Version: 1.0.16
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Janus WebRTC Gateway NethServer configuration
 Group: Network
 License: GPLv3


### PR DESCRIPTION
Spec: increment of spec version only to restart new released version of janus-gateway 0.7.6.0-2