### PR TITLE
Disable stdout log from command line

### DIFF
--- a/nethserver-janus.spec
+++ b/nethserver-janus.spec
@@ -2,12 +2,10 @@ Name:    nethserver-janus
 Version: 1.1.1
 Release: 1%{?dist}
 Summary: Janus WebRTC Gateway NethServer configuration
-Group: Network
 License: GPLv3
 BuildArch: noarch
-Packager: Nethesis <info@nethesis.it>
 Source0: %{name}-%{version}.tar.gz
-Requires: janus-gateway >= 0.10.2.1
+Requires: janus-gateway >= 0.10.2
 BuildRequires: nethserver-devtools
 
 %description
@@ -29,6 +27,7 @@ rm -rf %{buildroot}
 rm -rf %{buildroot}
 
 %files -f %{name}-%{version}-%{release}-filelist
+%license LICENSE
 %defattr(-,root,root,-)
 %dir %{_nseventsdir}/%{name}-update
 

--- a/root/etc/e-smith/templates/opt/janus/etc/janus/janus.jcfg/10base
+++ b/root/etc/e-smith/templates/opt/janus/etc/janus/janus.jcfg/10base
@@ -15,7 +15,7 @@ general: \{
 	events_folder = "/opt/janus/lib/janus/events"			# Event handlers folder
 
 	# The next settings configure logging
-	log_to_stdout = false						# Whether the Janus output should be written
+	#log_to_stdout = false						# Whether the Janus output should be written
 									# to stdout or not (default=true)
 	log_to_file = "/var/log/janus"					# Whether to use a log file or not
 	debug_level = 4							# Debug/logging level, valid values are 0-7

--- a/root/etc/logrotate.d/janus
+++ b/root/etc/logrotate.d/janus
@@ -1,9 +1,6 @@
 /var/log/janus {
    copytruncate
    missingok
-   rotate 1
-   compress
-   weekly
    create 0644 root root
 }
 


### PR DESCRIPTION
The command line switch `-N` disables stdout, if required. If we remove our setting here the stdout logging can be easily enabled/disabled from the command switches as needed.

Typical use case: run the daemon in production with `-N` and with `-L /dev/null -d 7` during debug.

nethesis/dev#5836