### PR TITLE
Hardcode ns8 network interface to ICE ignore list

### DIFF
--- a/root/etc/e-smith/templates/opt/janus/etc/janus/janus.jcfg/10base
+++ b/root/etc/e-smith/templates/opt/janus/etc/janus/janus.jcfg/10base
@@ -244,7 +244,7 @@ nat: \{
 	# name starts with 'vmnet', to skip VMware interfaces:
 {
 	my $ice_ignore_list = ${'janus-gateway'}{ICEIgnoreList} || 'vmnet';
-	$OUT.= "	ice_ignore_list = \"$ice_ignore_list\"";
+	$OUT.= "	ice_ignore_list = \"ns8,$ice_ignore_list\"";
 }
 \}
 


### PR DESCRIPTION
During migration to NethServer 8 a VPN is created with a network interface called "ns8". This interface is probed for ICE delaying the call

https://github.com/nethesis/ns8-nethvoice/issues/70
https://github.com/NethServer/dev/issues/5960